### PR TITLE
fix waybar opacity

### DIFF
--- a/waybar.css
+++ b/waybar.css
@@ -1,2 +1,2 @@
 @define-color foreground #eee8d5;
-@define-color background rgba(0, 43, 54, 0.7);
+@define-color background #002b36;


### PR DESCRIPTION
the labels on waybar don't inherit the opacity. this makes the background of waybar look the same the entire way across.